### PR TITLE
fix: types

### DIFF
--- a/packages/astro-font/utils.ts
+++ b/packages/astro-font/utils.ts
@@ -14,9 +14,9 @@ interface Source {
   preload?: boolean
   css?: Record<string, string>
   // https://developer.mozilla.org/en-US/docs/Web/CSS/font-style
-  style: 'normal' | 'italic' | 'oblique' | `oblique ${number}deg` | GlobalValues | {}
+  style: 'normal' | 'italic' | 'oblique' | `oblique ${number}deg` | GlobalValues | (string & {})
   // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
-  weight?: 'normal' | 'bold' | 'lighter' | 'bolder' | GlobalValues | FontWeight | `${FontWeight}` | {}
+  weight?: 'normal' | 'bold' | 'lighter' | 'bolder' | GlobalValues | FontWeight | `${FontWeight}` | (string & {})
 }
 
 interface Config {
@@ -33,7 +33,7 @@ interface Config {
   cssVariable?: string | boolean
   fallback: 'serif' | 'sans-serif' | 'monospace'
   // https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
-  display: 'auto' | 'block' | 'swap' | 'fallback' | 'optional' | {}
+  display: 'auto' | 'block' | 'swap' | 'fallback' | 'optional' | (string & {})
 }
 
 export interface Props {

--- a/packages/astro-font/utils.ts
+++ b/packages/astro-font/utils.ts
@@ -7,7 +7,7 @@ import { pickFontFileForFallbackGeneration } from './fallback.ts'
 
 type GlobalValues = 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset'
 
-type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900
+type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | (number & {})
 
 interface Source {
   path: string

--- a/packages/astro-font/utils.ts
+++ b/packages/astro-font/utils.ts
@@ -7,8 +7,6 @@ import { pickFontFileForFallbackGeneration } from './fallback.ts'
 
 type GlobalValues = 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset'
 
-type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | (number & {})
-
 interface Source {
   path: string
   preload?: boolean
@@ -16,7 +14,7 @@ interface Source {
   // https://developer.mozilla.org/en-US/docs/Web/CSS/font-style
   style: 'normal' | 'italic' | 'oblique' | `oblique ${number}deg` | GlobalValues | (string & {})
   // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
-  weight?: 'normal' | 'bold' | 'lighter' | 'bolder' | GlobalValues | FontWeight | `${FontWeight}` | (string & {})
+  weight?: 'normal' | 'bold' | 'lighter' | 'bolder' | GlobalValues | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900" | (string & {}) | (number & {})
 }
 
 interface Config {


### PR DESCRIPTION
According to https://stackoverflow.com/questions/61047551/typescript-union-of-string-and-string-literals, the right type to allow any string is not the one I initially suggested. It works but since there's a better way, here is a quick PR for it! cc @rishi-raj-jain 