### PR TITLE
Only inject a single `<style>` tag

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,0 @@
-{
-	"_variables": {
-		"lastUpdateCheck": 1722276947053
-	}
-}

--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1722276947053
+	}
+}

--- a/packages/astro-font/AstroFont.astro
+++ b/packages/astro-font/AstroFont.astro
@@ -11,4 +11,4 @@ const styles = Promise.all([...resolvedConfig.map(createBaseCSS), ...resolvedCon
 ---
 
 {preloads.flat().map((content) => <link as="font" crossorigin rel="preload" href={content} type={getPreloadType(content)} />)}
-{styles.then((res) => <style set:html={res.flat().reduce((total, content) => `${total}\n${content}`, '')} is:inline />).catch(console.log)}
+{styles.then((res) => <style set:html={res.flat().reduce((total, content) => total ? `${total}\n${content}` : content, '')} is:inline />).catch(console.log)}

--- a/packages/astro-font/AstroFont.astro
+++ b/packages/astro-font/AstroFont.astro
@@ -7,10 +7,8 @@ const { config } = Astro.props as Props
 const resolvedConfig = await generateFonts(config)
 
 const preloads = resolvedConfig.map(createPreloads)
-const baseCSS = Promise.all(resolvedConfig.map(createBaseCSS))
-const fallbackCSS = Promise.all(resolvedConfig.map(createFontCSS))
+const styles = Promise.all([...resolvedConfig.map(createBaseCSS), ...resolvedConfig.map(createFontCSS)])
 ---
 
 {preloads.flat().map((content) => <link as="font" crossorigin rel="preload" href={content} type={getPreloadType(content)} />)}
-{baseCSS.then((res) => res.flat().map((content) => <style set:html={content} is:inline />)).catch(console.log)}
-{fallbackCSS.then((res) => res.flat().map((content) => <style set:html={content} is:inline />)).catch(console.log)}
+{styles.then((res) => <style set:html={res.flat().reduce((total, content) => `${total}\n${content}`, '')} is:inline />).catch(console.log)}

--- a/packages/astro-font/AstroFont.astro
+++ b/packages/astro-font/AstroFont.astro
@@ -11,4 +11,4 @@ const styles = Promise.all([...resolvedConfig.map(createBaseCSS), ...resolvedCon
 ---
 
 {preloads.flat().map((content) => <link as="font" crossorigin rel="preload" href={content} type={getPreloadType(content)} />)}
-{styles.then((res) => <style set:html={res.flat().reduce((total, content) => total ? `${total}\n${content}` : content, '')} is:inline />).catch(console.log)}
+{styles.then((res) => <style set:html={res.flat().join(' ')} is:inline />).catch(console.log)}


### PR DESCRIPTION
Use a single style tag for all injected styles instead of using multiple.

This will come in handy on several occasions. One that I'm currently dealing with is creating sha256 hashes for every inline script and style tag for use in Content Security Policy.