### PR TITLE
✨ feat(font): add assetsPrefix support for CDN deployments

### DIFF
--- a/packages/astro-font/AstroFont.astro
+++ b/packages/astro-font/AstroFont.astro
@@ -1,10 +1,21 @@
 ---
-import type { Props } from './dist/utils'
+import type { Config } from './dist/utils'
 import { generateFonts, getPreloadType, createPreloads, createBaseCSS, createFontCSS } from './dist/utils'
 
-const { config } = Astro.props as Props
+interface Props {
+  config: Config[];
+  assetsPrefix?: string;
+}
 
-const resolvedConfig = await generateFonts(config)
+const { config: originalConfig, assetsPrefix } = Astro.props as Props
+
+const configWithPrefix: Config[] = originalConfig.map(conf => ({
+  ...conf,
+  // Add the assetsPrefix passed to the component to each font config
+  assetsPrefix: assetsPrefix,
+}));
+
+const resolvedConfig = await generateFonts(configWithPrefix)
 
 const preloads = resolvedConfig.map(createPreloads)
 const styles = Promise.all([...resolvedConfig.map(createBaseCSS), ...resolvedConfig.map(createFontCSS)])

--- a/packages/astro-font/utils.ts
+++ b/packages/astro-font/utils.ts
@@ -57,6 +57,7 @@ interface Config {
   fallback: 'serif' | 'sans-serif' | 'monospace'
   // https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
   display: 'auto' | 'block' | 'swap' | 'fallback' | 'optional' | (string & {})
+  assetsPrefix?: string
 }
 
 export interface Props {
@@ -72,7 +73,25 @@ const extToPreload = {
 }
 
 function getBasePath(src?: string) {
-  return src || './public'
+  return src || './public';
+}
+
+export function generatePublicUrl(localPath: string, basePath: string, assetsPrefix?: string): string {
+  if (localPath.startsWith('https:') || localPath.startsWith('http:')) {
+    return localPath;
+  }
+  // Calculate relative path using the logic similar to the original getRelativePath
+  const pathRelativeToPublic = relative(basePath, localPath);
+
+  if (assetsPrefix) {
+    // Ensure prefix ends with a slash and relative path doesn't start with one
+    const normalizedPrefix = assetsPrefix.endsWith('/') ? assetsPrefix : assetsPrefix + '/';
+    const normalizedRelative = pathRelativeToPublic.startsWith('/') ? pathRelativeToPublic.substring(1) : pathRelativeToPublic;
+    return normalizedPrefix + normalizedRelative;
+  } else {
+    // Original behavior: return root-relative path, ensuring it starts with '/'
+    return '/' + (pathRelativeToPublic.startsWith('/') ? pathRelativeToPublic.substring(1) : pathRelativeToPublic);
+  }
 }
 
 export function getRelativePath(from: string, to: string) {
@@ -330,27 +349,29 @@ async function getFallbackFont(fontCollection: Config): Promise<Record<string, s
 }
 
 export function createPreloads(fontCollection: Config): string[] {
-  // If the parent preload is set to be false, look for true only preload values
-  if (fontCollection.preload === false) {
-    return fontCollection.src
-      .filter((i) => i.preload === true)
-      .map((i) => getRelativePath(getBasePath(fontCollection.basePath), i.path))
-  }
-  // If the parent preload is set to be true (or not defined), look for non-false values
-  return fontCollection.src
-    .filter((i) => i.preload !== false)
-    .map((i) => getRelativePath(getBasePath(fontCollection.basePath), i.path))
+  const effectiveBasePath = getBasePath(fontCollection.basePath);
+  const sourcesToPreload = fontCollection.preload === false
+    ? fontCollection.src.filter((i) => i.preload === true)
+    : fontCollection.src.filter((i) => i.preload !== false);
+
+  // Generate public URLs using the new function
+  return sourcesToPreload.map((i) =>
+    generatePublicUrl(i.path, effectiveBasePath, fontCollection.assetsPrefix)
+  );
 }
 
 export async function createBaseCSS(fontCollection: Config): Promise<string[]> {
   try {
+    const effectiveBasePath = getBasePath(fontCollection.basePath); 
     const tmp = fontCollection.src.map((i) => {
       const cssProperties = Object.entries(i.css || {}).map(([key, value]) => `${key}: ${value}`)
       if (i.weight) cssProperties.push(`font-weight: ${i.weight}`)
       if (i.style) cssProperties.push(`font-style: ${i.style}`)
       if (fontCollection.name) cssProperties.push(`font-family: '${fontCollection.name}'`)
       if (fontCollection.display) cssProperties.push(`font-display: ${fontCollection.display}`)
-      cssProperties.push(`src: url(${getRelativePath(getBasePath(fontCollection.basePath), i.path)})`)
+      
+      const publicUrl = generatePublicUrl(i.path, effectiveBasePath, fontCollection.assetsPrefix);
+      cssProperties.push(`src: url(${publicUrl})`);
       return `@font-face {${cssProperties.join(';')}}`
     })
     return tmp


### PR DESCRIPTION
**Description:**

This pull request introduces a new optional `assetsPrefix` configuration property to `astro-font`. This feature allows users to specify a custom URL prefix for generated font assets (`@font-face` src URLs and `<link rel="preload">` hrefs), enabling seamless integration with CDNs or projects where assets are served from a non-root path, as configured via Astro's `build.assetsPrefix`.

**Problem:**

Currently, `astro-font` generates root-relative URLs for font assets (e.g., `/fonts/font.woff2`). This works well for standard setups but breaks when using Astro's `build.assetsPrefix` feature to serve assets from a different domain (CDN) or a subpath (e.g., `https://mycdn.com/assets/` or `/my-base-path/`). In such cases, the browser attempts to load fonts from the main site's root instead of the designated asset prefix, leading to 404 errors.

While `astro-font` correctly uses local font paths for its internal analysis (calculating fallback metrics for CLS optimization), the final output URLs do not respect the `assetsPrefix`.

**Solution:**

This PR implements the following changes:

1.  **Added `assetsPrefix?: string`:** A new optional property is added to the main `Config` interface within `utils.ts`.
2.  **Passed `assetsPrefix` Prop:** The `<AstroFont>` component now accepts an optional `assetsPrefix` prop. This single prop value is then merged into each individual font configuration object internally.
3.  **Introduced `generatePublicUrl` Utility:** A new function `generatePublicUrl(localPath, basePath, assetsPrefix)` is created in `utils.ts`. This function handles the logic for generating the final public URL:
    *   If `assetsPrefix` is provided, it prepends the prefix to the font path relative to the project's public directory (determined by `basePath`).
    *   If `assetsPrefix` is not provided, it defaults to the original behavior, generating a root-relative path (`/path/to/font.woff2`).
    *   It correctly handles existing absolute URLs (e.g., `https://...`) passed in `src.path`, returning them directly.
4.  **Updated URL Generation:** The `createPreloads` and `createBaseCSS` functions now utilize `generatePublicUrl` to ensure the correct prefix is applied when generating `<link>` tags and `src: url(...)` values in `@font-face` rules.
5.  **Maintained Local Analysis:** The core logic for reading font files (`getFontBuffer`, `getFallbackFont`) continues to use the *local filesystem path* provided in `src.path`, ensuring the CLS optimization via fallback metric calculation remains unaffected and functions correctly even when `assetsPrefix` is used. This also ensures compatibility with the `fetch: true` option (where the font is downloaded locally first, and the `assetsPrefix` is then applied to the *local generated path*).

**How to Use:**

1.  Determine your assets prefix (e.g., from Astro's `build.assetsPrefix` or your CDN URL).
2.  Pass this prefix as a prop to the `<AstroFont>` component:

```astro
---
import { AstroFont } from "astro-font";
import { join } from "path";
// Example: Get prefix from environment or config helper
const assetsPrefix = import.meta.env.ASSETS_PREFIX || "https://mycdn.com/assets";

const interLocalPath = join(process.cwd(), "public", "fonts", "Inter-Regular.woff2");
---

<AstroFont
  assetsPrefix={assetsPrefix}
  config={[
    {
      name: "Inter",
      src: [
        {
          // Local path for analysis
          path: interLocalPath,
          style: "normal",
          weight: "400",
        }
      ],
      display: "swap",
      fallback: "sans-serif",
      cssVariable: "font-inter"
    }
    // ... other fonts
  ]}
/>
```

The resulting preload links and CSS URLs will now be correctly prefixed, e.g.:

*   `href="https://mycdn.com/assets/fonts/Inter-Regular.woff2"`
*   `src: url(https://mycdn.com/assets/fonts/Inter-Regular.woff2)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced font configuration to support an optional custom prefix for asset URLs.
	- Improved asset URL generation for more reliable handling of both absolute and relative paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->