### PR TITLE
fs: fix Windows path handling in font directory copying

### DIFF
--- a/packages/astro-font/integration.ts
+++ b/packages/astro-font/integration.ts
@@ -1,4 +1,5 @@
 import type { AstroIntegration } from 'astro'
+import { fileURLToPath } from 'node:url'
 
 export function astroFont(): AstroIntegration {
   let publicDirectory = './public'
@@ -11,8 +12,8 @@ export function astroFont(): AstroIntegration {
       },
       'astro:build:done': async ({ dir }) => {
         const { existsSync, cpSync, readdirSync } = await import('node:fs')
-        const { join } = await import('node:path')
-        const buildDir = dir.pathname
+        const { join, resolve } = await import('node:path')
+        const buildDir = resolve(fileURLToPath(dir))
         function findAndCopyFontDirs(currentDir: string, relPath: string = '') {
           const entries = readdirSync(currentDir, { withFileTypes: true })
           for (const entry of entries) {
@@ -20,7 +21,7 @@ export function astroFont(): AstroIntegration {
             const relativePath = join(relPath, entry.name)
             if (entry.isDirectory()) {
               if (entry.name === '__astro_font_generated__') {
-                const targetPath = join(buildDir, relativePath)
+                const targetPath = resolve(buildDir, relativePath)
                 cpSync(fullPath, targetPath, { recursive: true })
               } else findAndCopyFontDirs(fullPath, relativePath)
             }


### PR DESCRIPTION
The astro:build:done hook fails on Windows with malformed paths like 'E:\E:\folder\...' due to improper URL-to-path conversion and path concatenation.

- Use resolve() instead of join() to ensure absolute paths and fix Windows separators
- Replace dir.pathname with fileURLToPath(dir) for proper URL conversion

Fixes: ENOPROTOOPT errors on Windows during font directory copying

---

I haven't done extensive testing, but seems to fix it for me. An example error:

```
01:49:44 [ERROR] [astro-font] An unhandled error occurred while running the "astro:build:done" hook
ENOPROTOOPT, The filename, directory name, or volume label syntax is incorrect. '\\?\DRIVE:\DRIVE:\PATH\TO\PROJECT\dist\__astro_font_generated__'
  Location:
    DRIVE:\PATH\TO\PROJECT\node_modules\astro-font\dist\integration.js:1:471
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build directory path resolution with proper file URL handling for consistent behavior across environments (e.g., Windows, ESM).
  * Prevents incorrect target paths during asset copying, reducing build errors and missing files in the output.
  * More robust handling of absolute/relative paths to avoid edge cases.
  * No changes to the public API; existing integrations continue to work without modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->