### PR TITLE
fix(integration): use fileURLToPath to correctly resolve the build dir path on Windows

### DIFF
--- a/packages/astro-font/integration.ts
+++ b/packages/astro-font/integration.ts
@@ -12,7 +12,8 @@ export function astroFont(): AstroIntegration {
       'astro:build:done': async ({ dir }) => {
         const { existsSync, cpSync, readdirSync } = await import('node:fs')
         const { join } = await import('node:path')
-        const buildDir = dir.pathname
+        const { fileURLToPath } = await import('node:url')
+        const buildDir = fileURLToPath(dir)
         function findAndCopyFontDirs(currentDir: string, relPath: string = '') {
           const entries = readdirSync(currentDir, { withFileTypes: true })
           for (const entry of entries) {


### PR DESCRIPTION
Resolves #35 

From Node.js [docs](https://nodejs.org/api/url.html#urlfileurltopathurl-options):
```js
new URL('file:///C:/path/').pathname;      // Incorrect: /C:/path/
fileURLToPath('file:///C:/path/');         // Correct:   C:\path\ (Windows)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build directory path resolution to ensure correct handling of file paths during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->