### PR TITLE
Fix utils export path

### DIFF
--- a/packages/astro-font/package.json
+++ b/packages/astro-font/package.json
@@ -12,8 +12,8 @@
       "default": "./index.js"
     },
     "./utils": {
-      "types": "./dist/util.d.ts",
-      "default": "./dist/util.js"
+      "types": "./dist/utils.d.ts",
+      "default": "./dist/utils.js"
     },
     "./integration": {
       "types": "./dist/integration.d.ts",


### PR DESCRIPTION
## Summary
- point the ./utils export to dist/utils.js and dist/utils.d.ts
- keep the package export map aligned with the files produced by the astro-font build

## Verification
- npm run build in packages/astro-font
- npm pack the fixed package, install the tarball into a clean project, and import astro-font/utils at runtime
- compile a clean TypeScript project importing generateFonts from astro-font/utils with npx tsc --noEmit

The published package currently points ./utils at dist/util.js and dist/util.d.ts, but the tarball contains dist/utils.js and dist/utils.d.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected the package exports configuration for the utilities module to reference the correct build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->