### PR TITLE
Fix astro-font/utils export path

### DIFF
--- a/packages/astro-font/package.json
+++ b/packages/astro-font/package.json
@@ -12,8 +12,8 @@
       "default": "./index.js"
     },
     "./utils": {
-      "types": "./dist/util.d.ts",
-      "default": "./dist/util.js"
+      "types": "./dist/utils.d.ts",
+      "default": "./dist/utils.js"
     },
     "./integration": {
       "types": "./dist/integration.d.ts",


### PR DESCRIPTION
﻿## Summary

Fix the published `astro-font/utils` subpath export so it points at the files the package actually builds and publishes.

`packages/astro-font/package.json` currently maps `./utils` to singular `dist/util.*` files:

```json
"./utils": {
  "types": "./dist/util.d.ts",
  "default": "./dist/util.js"
}
```

The build emits and the npm tarball publishes plural `dist/utils.js` and `dist/utils.d.ts`, so clean consumers get `ERR_MODULE_NOT_FOUND` when importing `astro-font/utils`.

## Change

Update the `./utils` export to point at `./dist/utils.js` and `./dist/utils.d.ts`.

## Validation

Reproduced against the published package:

```text
npm install --ignore-scripts --no-audit --no-fund astro-font@1.1.0
node --input-type=module -e "await import('astro-font/utils')"
ERR_MODULE_NOT_FOUND: Cannot find module '.../node_modules/astro-font/dist/util.js'
```

Validated this branch:

```text
pnpm install --frozen-lockfile
pnpm build:astro-font
pnpm pack --json
# tarball includes package/dist/utils.js and package/dist/utils.d.ts
clean consumer install from local tgz
node --input-type=module -e "const m = await import('astro-font/utils'); console.log(Object.keys(m).slice(0,5))"
# import succeeds
pnpm exec prettier --check packages/astro-font/package.json
git diff --check
```

Note: `npm install` from the local tarball prints existing `TAR_ENTRY_ERROR path contains '..'` warnings because the package `files` list contains `../../README.md`. That is pre-existing and unrelated to this export path fix; the tarball still installs and the subpath import succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected package export path mappings for the utilities module to ensure proper package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->